### PR TITLE
Minor tweaks to allow alternative approaches

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@ If you need help with the challenge, for whatever reason, please do drop us an e
 
 ## Tasks
 
-1. Build a page to show the current astronauts that are in space, using the `OpenNotify#astros` method.
-  * Use the existing `position` page as a guide when adding this new page.
+1. Build a page to show the current astronauts that are in space.
+  * You can either add to this codebase using the `OpenNotify#astros` method and use the existing `position` page as a guide when adding this new page.
+  * Alternatively you could obtain the data from the `http://localhost:4567/astros` endpoint and use this codebase as an API utilising whatever framework you choose as the frontend.
 2. Add some style to the application using HTML and CSS, prioritising clear information presentation.
   * Location data should be shown on the `position` page.
   * Astronauts and their space ships could be shown in a table, or a list.

--- a/app.rb
+++ b/app.rb
@@ -18,3 +18,10 @@ get '/position' do
 
   erb :position, locals: { data: iss_now }
 end
+
+get '/astros' do
+  astros = OpenNotify.astros
+
+  content_type :json
+  astros.to_json
+end


### PR DESCRIPTION
By introducing an API endpoint (`/astros`) candidates can utilise another framework for their frontend if they want to.